### PR TITLE
Publish packages to npm via ci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,6 +11,10 @@ test:
       if [ "$CIRCLE_BRANCH" == "master" ]; then
         echo "Publishing all charts..."
         for chart in $(find charts/ -maxdepth 1 -mindepth 1 -type d -printf "%f\n"); do
+          if [ "$chart" == "template" ]; then # This isn't a chart, but a template for `./make-chart`
+            continue
+          fi
+
           echo
           echo
           echo "================"


### PR DESCRIPTION
We've had an issue where we'd forget to publish stuff that was in master. If CI does all the publishing, we can't forget to do it.