### PR TITLE
chore(bug): fix vertical offset line chart issue

### DIFF
--- a/src/charts/line-chart/axes.js
+++ b/src/charts/line-chart/axes.js
@@ -128,10 +128,9 @@ export function yAxisMinMax({
         let x = -1 * (leftMargin - leftOffset);
         let y = scale(d.value) + axisFontSize * 0.4;
 
-        // Adjust the first datapoint to match with the vertical baseline of the chart.
-        if (d.value === firstEventYValue) {
-          y -= (defaultDataset.verticalBaselineOffset || 0);
-        }
+        // Adjust datapoints upward to take into account vertical offset defined on default dataset
+        y -= (defaultDataset.verticalBaselineOffset || 0);
+
         return `translate(${x},${y})`;
       });
     mergeSelection.select('.axis-y-point-label')
@@ -161,7 +160,7 @@ export function yAxisMinMax({
       .attr('x', leftMargin - leftOffset)
       .attr('y', -1 * (axisFontSize * 0.4))
       .attr('width', graphWidth)
-      .attr('height', d => scale(0) - scale(d.value))
+      .attr('height', d => (scale(0) - scale(d.value)) + (defaultDataset.verticalBaselineOffset || 0))
       .attr('fill', d => {
         if (d.hasShadow) {
           return 'rgba(65, 152, 255, 0.1)';


### PR DESCRIPTION
If a vertical offset was defined, this would cause overlays and rules to
be offset upward by the number of pixels included in the offset. Fixed
by applying the inverse offset to all y axis values.

Before:
![screen shot 2018-06-07 at 3 47 16 pm](https://user-images.githubusercontent.com/1704236/41122600-14125e94-6a6a-11e8-9619-66769993ebdc.png)


After:
![screen shot 2018-06-07 at 3 46 46 pm](https://user-images.githubusercontent.com/1704236/41122588-09cf8d76-6a6a-11e8-8b75-57fe1529d4e7.png)
