### PR TITLE
Update density ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/charts",
-  "version": "0.7.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@density/charts",
-  "version": "0.7.0",
+  "version": "1.0.0",
   "description": "A bunch of charts we use in all of our dashboards",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "@density/node-sass-json-importer": "^4.1.0",
     "@density/ui": "^5.0.1",
     "create-react-class": "^15.5.2",
-    "react": "^16.3.2",
-    "react-scripts": "1.0.14"
+    "react": "^16.3.2"
   },
   "devDependencies": {
     "@storybook/addon-actions": "^3.2.12",
@@ -40,6 +39,7 @@
     "react-dom": "^16.3.2",
     "sass-loader": "^6.0.3",
     "style-loader": "^0.17.0",
-    "webpack": "^2.3.2"
+    "webpack": "^2.3.2",
+    "react-scripts": "1.0.14"
   }
 }


### PR DESCRIPTION
Well, it turns out that @density/charts depended on @density/ui. This is a bad idea - it means that if @density/ui is upgraded in the final project, then the upgrade has to also be done in @density/charts. Instead, make this a peer-dependency, so that the existing version of the package in the final project can be used instead.

Old:
```
O
|- @density/charts
|  \- @density/ui
|
\- @density/ui
```

New:
```
O
|- @density/charts
\- @density/ui
```